### PR TITLE
Round numbers into 8bit before assigning bytes

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,9 +140,9 @@ function decodeChars(inBytes, inIndex, outBytes, outIndex) {
 	var b2 = (c2 - 32 & 0x3F) << 4 | (c3 - 32 & 0x3F) >> 2;
 	var b3 = (c3 - 32 & 0x3F) << 6 | c4 - 32 & 0x3F;
 
-	outBytes[outIndex] = b1;
-	outBytes[outIndex + 1] = b2;
-	outBytes[outIndex + 2] = b3;
+	outBytes[outIndex] = b1 & 0xFF;
+	outBytes[outIndex + 1] = b2 & 0xFF;
+	outBytes[outIndex + 2] = b3 & 0xFF;
 }
 
 // exports


### PR DESCRIPTION
Assigning values over 0xFF into Buffer's bytes works well in Node.js, as it cut out unnecessary bits over 8. But this behavior isn't documented nor supported on [Buffer for Browser](https://github.com/feross/buffer). So we shouldn't expect it to do that and should manually round numbers into 8bit before assigning bytes.